### PR TITLE
Added second autosave point and save events

### DIFF
--- a/CvGameCoreDLLUtil/include/CvEnums.h
+++ b/CvGameCoreDLLUtil/include/CvEnums.h
@@ -1312,6 +1312,10 @@ enum GameOptionTypes
 #define GAMEOPTION_RANDOM_VICTORY			"GAMEOPTION_RANDOM_VICTORY"
 #endif
 
+#if defined(MOD_SAVE_CONTROLLER)
+#define GAMEOPTION_POST_AUTOSAVES			"GAMEOPTION_POST_AUTOSAVES"
+#endif
+
 enum MultiplayerOptionTypes		
 {
 	NO_MPOPTION = -1,

--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -40,6 +40,11 @@
 //END MULTIPLAYER INSTRUCTIONS
 ////////////////////////////////////////
 
+// Sorry, I am putting this here since I don't quite know where to put it! Please advise and/or move
+// Enables autosaving GameEvents and allows and extra autosave after Barbs/AI turn in
+#define MOD_SAVE_CONTROLLER	(true)
+
+
 ///////////////////////
 // BATTLE ROYALE CODE
 //////////////////////
@@ -1292,6 +1297,9 @@ enum BattleTypeTypes
 #define GAMEEVENT_CityFlipped				"CityFlipped", "iii"
 #define GAMEEVENT_CityFlipChance			"CityFlipChance", "ii"
 #define GAMEEVENT_CityFlipRecipientChance	"CityFlipChance", "iii"
+// AutoSave
+#define GAMEEVENT_WantAutoSave				"WantAutoSave",		"i"
+#define GAMEEVENT_AutoSaved					"AutoSaved",		"ib"
 
 // Serialization wrappers
 #define MOD_SERIALIZE

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -39,6 +39,9 @@ class CvGameCorporations;
 class CvGameContracts;
 #endif
 
+#if defined(MOD_SAVE_CONTROLLER)
+class CvSaveController;
+#endif 
 class CvGameInitialItemsOverrides
 {
 public:
@@ -695,6 +698,9 @@ public:
 	int GetNextGlobalID() { return ++m_iGlobalAssetCounter; }
 #endif
 
+#if defined(MOD_SAVE_CONTROLLER)
+	CvSaveController* getSaveController();
+#endif
 	void SetClosestCityMapDirty();
 	//assuming a typical unit with baseMoves==2
 	int GetClosestCityDistanceInTurns( const CvPlot* pPlot );
@@ -878,6 +884,10 @@ protected:
 #if defined(MOD_BALANCE_CORE)
 	CvGameCorporations*		   m_pGameCorporations;
 	CvGameContracts*		   m_pGameContracts;
+#endif
+
+#if defined(MOD_SAVE_CONTROLLER)
+	CvSaveController* m_pSaveController;
 #endif
 
 	//necessary because we only want to hide the mouseover of the most recently moused over unit -KS

--- a/CvGameCoreDLL_Expansion2/CvSaveController.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSaveController.cpp
@@ -1,0 +1,215 @@
+#include "CvGameCoreDLLPCH.h"
+#include "CvSaveController.h"
+
+// must be included after all other headers
+#include "LintFree.h"
+
+
+enum AutoSaveModeTypes
+{
+	NO_AUTOSAVE = -1,
+
+	AUTOSAVE_MODE_NONE,
+	AUTOSAVE_MODE_INITIAL,
+	AUTOSAVE_MODE_NORMAL,
+	AUTOSAVE_MODE_POST,
+
+
+	NUM_AUTOSAVE_MODE,
+};
+
+
+struct ManualSaveArgs
+{
+	ICvEngineScriptSystem1* pkScriptSystem;
+	const char* filename;
+	bool bSuccess;
+};
+
+namespace {
+	int UnsafeUISave(lua_State* L) {
+
+		ManualSaveArgs* pArgs = (ManualSaveArgs*)lua_touserdata(L, 1);
+
+		pArgs->bSuccess = false;
+		lua_getglobal(L, "UI");
+		lua_getfield(L, -1, "SaveGame");
+		lua_pushstring(L, pArgs->filename);
+		lua_pcall(L, 1, 0, 0);
+
+		pArgs->bSuccess = true;
+
+		return 0;
+	}
+
+
+	bool ManualSave(const char* filename)
+	{
+		ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
+		lua_State* l = pkScriptSystem->CreateLuaThread("Manual Save");
+
+		ManualSaveArgs args;
+		args.pkScriptSystem = pkScriptSystem;
+		args.filename = filename;
+		args.bSuccess = false;
+
+		pkScriptSystem->CallCFunction(l, UnsafeUISave, &args);
+
+		pkScriptSystem->FreeLuaThread(l);
+		return args.bSuccess;
+	}
+}
+
+CvSaveController::CvSaveController()
+{
+	for (int i = 0; i < NUM_AUTOSAVE_POINT; i++)
+	{
+		iLastTurnSaved[i] = -1;
+		iTurnChecked[i] = -1;
+	}
+
+	m_bSkipFirstNetworkGameHumanTurnsStartSave = false;
+	m_eSavedPoint = AUTOSAVE_POINT_EXTERNAL;
+	m_eLastSavedPoint = NO_AUTOSAVE_POINT;
+
+}
+
+CvSaveController::~CvSaveController()
+{
+}
+
+bool CvSaveController::SavePoint(AutoSavePointTypes eSavePoint) {
+	if (iTurnChecked[eSavePoint] == GC.getGame().getGameTurn())	{
+		return false;
+	}
+	else {
+		iTurnChecked[eSavePoint] = GC.getGame().getGameTurn();
+	}
+	
+	if (m_bSkipFirstNetworkGameHumanTurnsStartSave && eSavePoint == AUTOSAVE_POINT_NETWORK_GAME_TURN_POST)
+	{
+		m_bSkipFirstNetworkGameHumanTurnsStartSave = false;
+		return false;
+	}
+	
+	if (iLastTurnSaved[eSavePoint] == GC.getGame().getGameTurn())
+	{
+		return false;
+	}
+	
+	bool isInitial = false;
+	bool isPost = false;
+	switch (eSavePoint)
+	{
+
+		case AUTOSAVE_POINT_MAP_GEN:
+		case AUTOSAVE_POINT_INITIAL:
+			isInitial = true;	
+			isPost = false;
+			break;
+
+		case AUTOSAVE_POINT_LOCAL_GAME_TURN:
+		case AUTOSAVE_POINT_NETWORK_GAME_TURN:
+			isInitial = false;
+			isPost = false;
+			break;
+
+		case AUTOSAVE_POINT_LOCAL_GAME_TURN_POST:
+		case AUTOSAVE_POINT_NETWORK_GAME_TURN_POST:
+			isInitial = false;
+			isPost = true;
+			break;
+	
+	}
+	bool bPostAutoSavesDefault = GC.getGame().isOption(GAMEOPTION_POST_AUTOSAVES);
+	AutoSave(eSavePoint, isInitial || !isPost || bPostAutoSavesDefault, isInitial, isPost);
+	
+	return true;
+
+}
+
+AutoSavePointTypes CvSaveController::getLastAutoSavePoint() const
+{
+	return m_eLastSavedPoint;
+}
+
+int CvSaveController::getLastAutoSaveTurn() const
+{
+	if (m_eLastSavedPoint == NO_AUTOSAVE_POINT)
+		return -1;
+	return iLastTurnSaved[m_eLastSavedPoint];
+}
+
+bool CvSaveController::AutoSave(AutoSavePointTypes eSavePoint, bool default, bool initial, bool post)
+{
+	bool save = initial;
+
+	if(!save)
+		save = FireWantAutoSaveEvent(eSavePoint, default);
+	if (save) {
+		m_eSavedPoint = eSavePoint;					
+		gDLL->AutoSave(initial, post);
+		m_eSavedPoint = AUTOSAVE_POINT_EXTERNAL;
+		m_eLastSavedPoint = eSavePoint;
+
+		iLastTurnSaved[eSavePoint] = GC.getGame().getGameTurn();	
+	}
+	FireAutoSaveEvent(eSavePoint, save); // sending whether saved or not because it might be useful information to listeners and allow more functionality, especially since listening to the "want" message has side effects
+	return save;
+}
+
+bool CvSaveController::FireWantAutoSaveEvent(AutoSavePointTypes eSavePoint, bool default)
+{
+	int result =  GAMEEVENTINVOKE_TESTANY(GAMEEVENT_WantAutoSave, eSavePoint);
+	bool save = false;
+	
+	if (result == GAMEEVENTRETURN_TRUE) save = true;
+	else if (result == GAMEEVENTRETURN_FALSE) save = false;
+	else save = default;
+
+	return save;
+}
+
+void CvSaveController::FireAutoSaveEvent(AutoSavePointTypes eSavePoint, bool saved)
+{
+	GAMEEVENTINVOKE_HOOK(GAMEEVENT_AutoSaved, eSavePoint, saved);
+}
+
+void CvSaveController::Save(const char* filename)
+{
+	NamedSave(filename, AUTOSAVE_POINT_EXPLICIT);
+}
+
+void CvSaveController::NamedSave(const char* filename, AutoSavePointTypes type) {
+	m_eSavedPoint = type;
+	ManualSave(filename);
+	m_eSavedPoint = AUTOSAVE_POINT_EXTERNAL;
+	FireAutoSaveEvent(type, true);
+
+}
+
+void CvSaveController::Read(FDataStream& kStream)
+{
+	int p;
+	kStream >> p;
+	AutoSavePointTypes eLoadedSavePoint = (AutoSavePointTypes)p;
+	if (eLoadedSavePoint == AUTOSAVE_POINT_NETWORK_GAME_TURN_POST)
+		m_bSkipFirstNetworkGameHumanTurnsStartSave = true;
+
+}
+
+void CvSaveController::Write(FDataStream& kStream) const
+{
+	kStream << (int)m_eSavedPoint;
+}
+
+FDataStream& operator>>(FDataStream& kStream, CvSaveController& kAutoSave)
+{
+	kAutoSave.Read(kStream);
+	return kStream;
+}
+FDataStream& operator<<(FDataStream& kStream, const CvSaveController& kAutoSave)
+{
+	kAutoSave.Write(kStream);
+	return kStream;
+}

--- a/CvGameCoreDLL_Expansion2/CvSaveController.h
+++ b/CvGameCoreDLL_Expansion2/CvSaveController.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#ifndef CV_AUTOSAVE2_H
+#define CV_AUTOSAVE2_H
+
+#include <string>
+
+enum AutoSavePointTypes
+{
+	NO_AUTOSAVE_POINT = -1,
+
+	AUTOSAVE_POINT_EXTERNAL,
+
+	AUTOSAVE_POINT_EXPLICIT,
+
+	AUTOSAVE_POINT_MAP_GEN,
+	AUTOSAVE_POINT_INITIAL,
+
+	AUTOSAVE_POINT_LOCAL_GAME_TURN,
+	AUTOSAVE_POINT_NETWORK_GAME_TURN,
+
+	AUTOSAVE_POINT_LOCAL_GAME_TURN_POST,
+	AUTOSAVE_POINT_NETWORK_GAME_TURN_POST,
+
+	NUM_AUTOSAVE_POINT,
+};
+
+class CvSaveController
+{
+public:
+	CvSaveController();
+	virtual ~CvSaveController();
+
+	bool SavePoint(AutoSavePointTypes eSavePoint);
+	
+	AutoSavePointTypes getLastAutoSavePoint() const;
+	int getLastAutoSaveTurn() const;
+
+	void Read(FDataStream& kStream);
+	void Write(FDataStream& kStream) const;
+
+	// Save games using this method are not guaranteed to be in a good state since they could be made at any point during processing
+	// Provided for developement and debugging purposes...and for the adventurous!
+	void Save(const char* filename);
+
+
+protected:
+	bool AutoSave(AutoSavePointTypes eSavePoint, bool default, bool initial, bool post);
+
+	void NamedSave(const char* filename, AutoSavePointTypes type);
+
+	bool FireWantAutoSaveEvent(AutoSavePointTypes eSavePoint, bool default);
+	void FireAutoSaveEvent(AutoSavePointTypes eSavePoint, bool saved);
+
+	int iLastTurnSaved[NUM_AUTOSAVE_POINT];
+	int iTurnChecked[NUM_AUTOSAVE_POINT];
+
+	AutoSavePointTypes m_eSavedPoint;
+	AutoSavePointTypes  m_eLastSavedPoint;
+
+	bool m_bSkipFirstNetworkGameHumanTurnsStartSave;	
+};
+
+FDataStream& operator>>(FDataStream&, CvSaveController&);
+FDataStream& operator<<(FDataStream&, const CvSaveController&);
+
+#endif

--- a/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
+++ b/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
@@ -554,6 +554,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Use</PrecompiledHeader>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CvGameCoreDLLPCH.h</PrecompiledHeaderFile>
     </ClCompile>
+    <ClCompile Include="CvSaveController.cpp" />
     <ClCompile Include="CvSiteEvaluationClasses.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Use</PrecompiledHeader>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CvGameCoreDLLPCH.h</PrecompiledHeaderFile>
@@ -851,6 +852,7 @@
     <ClInclude Include="CvReligionClasses.h" />
     <ClInclude Include="CvReplayInfo.h" />
     <ClInclude Include="CvReplayMessage.h" />
+    <ClInclude Include="CvSaveController.h" />
     <ClInclude Include="CvSiteEvaluationClasses.h" />
     <ClInclude Include="CvStartPositioner.h" />
     <ClInclude Include="cvStopWatch.h" />


### PR DESCRIPTION
(Copying pull request from @davenye)

Due to the barrier on the finshing of ai processing, it looks like it might be safe to slot in a second autosave point after AI has finished but before humans.

Unfortunately, saving at this point can result in a slightly unpleasant stuttering of the game. Nothing too bad but some may not like it and not want it enabled. Also because of the was MP saves work the post ai save will be used for manually saved games also.

In order to give people better choice as to when to have the post ai save enabled I have also added a couple of GameEvents which allow the saves to be enabled/disabled on an indivual basis, turn by turn.

It is quite barebones and actually removed features since I am wary of enlarging the API. I have implemented a separate Lua UI mod that gives fine grained control over saves as a proof of concept, at least. It is pretty nasty and wouldn't be included in VP in the current state. It is something that is probably best left to the mod modders and now the tools are there.