### PR TITLE
fix bug where plot reveal was dependant on active player

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -11196,22 +11196,13 @@ PlotVisibilityChangeResult CvPlot::changeVisibilityCount(TeamTypes eTeam, int iC
 	if (bOldVisibility == false && isVisible(eTeam))
 	{
 		eResult = VISIBILITY_CHANGE_TO_VISIBLE;
-
+		
+		bool alreadyRevealed = isRevealed(eTeam); // result from setRevealed is not just a simple "we reveled a new plot to the player" and was causing all sorts of issues (poor ai explore decisions, desyncs, etc).
 #if defined(MOD_API_EXTENSIONS)
-		if (setRevealed(eTeam, true, pUnit))	// Change to revealed, returns true if the visibility was changed
+		if (!setRevealed(eTeam, true, pUnit))	// Change to revealed, returns true if the visibility was changed
 #else
-		if (setRevealed(eTeam, true))	// Change to revealed, returns true if the visibility was changed
+		if (!setRevealed(eTeam, true))	// Change to revealed, returns true if the visibility was changed
 #endif
-		{
-			//we are seeing this plot for the first time
-			if (bInformExplorationTracking)
-			{
-				vector<PlayerTypes> vPlayers = GET_TEAM(eTeam).getPlayers();
-				for (size_t i = 0; i < vPlayers.size(); i++)
-					GET_PLAYER(vPlayers[i]).GetEconomicAI()->UpdateExplorePlotsLocally(this);
-			}
-		}
-		else
 		{
 			// The visibility was not changed because it was already revealed, but we are changing to a visible state as well, so we must update.
 			// Just trying to avoid redundant messages.
@@ -11221,6 +11212,14 @@ PlotVisibilityChangeResult CvPlot::changeVisibilityCount(TeamTypes eTeam, int iC
 				updateFog(true);
 				updateVisibility();
 			}
+		}
+
+		//we are seeing this plot for the first time		
+		if (!alreadyRevealed && isRevealed(eTeam) && bInformExplorationTracking)
+		{
+			vector<PlayerTypes> vPlayers = GET_TEAM(eTeam).getPlayers();
+			for (size_t i = 0; i < vPlayers.size(); i++)
+				GET_PLAYER(vPlayers[i]).GetEconomicAI()->UpdateExplorePlotsLocally(this);
 		}
 
 		for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)


### PR DESCRIPTION
By @davenye:

> Return value from CvPlot::setRevealed is more nuanced than simply
> returning whether the plot is being revealed to the team.
> 
> Now using a simple check.
> 
> This bug causes all sorts of problems, particularly desyncs in MP.
> While the position is possibly synced with host, the visibilty of the
> plots is not. This means things like barb camps get spawned in different
> locations on different machines. This will be responsible for a large
> number of desyncs for people who autoexplore.
> 
> Also, it causes the AI to explore suboptimally.
> 
> Will result in slightly more processing but it is the right thing to do.